### PR TITLE
modify by RN latest version

### DIFF
--- a/src/Tree.js
+++ b/src/Tree.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {ScrollView, View, Text, TouchableOpacity, Dimensions } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import MyUtils from './MyUtils'


### PR DESCRIPTION
According to the latest version of RN, import  { PropTypes } from 'react'  is not the correct way to write。 It should be the following style of writing: import PropTypes from 'prop-types';